### PR TITLE
Fixes build for MacOS

### DIFF
--- a/synth/build.rs
+++ b/synth/build.rs
@@ -1,6 +1,11 @@
 extern crate nasm_rs;
 
 fn main() {
+	#[cfg(not(target_env = "msvc"))]
+	nasm_rs::compile_library("libadditive.a", &["src/additive.asm"]);
+
+	#[cfg(target_env = "msvc")]
 	nasm_rs::compile_library("additive.lib", &["src/additive.asm"]);
+
 	println!("cargo:rustc-link-lib=static=additive");
 }

--- a/synth/src/additive.asm
+++ b/synth/src/additive.asm
@@ -5,7 +5,11 @@
 %define PSIZE 4
 %define STACK_OFFSET (4*4 + 4)
 %else
+%ifidn __OUTPUT_FORMAT__, win64
 %define NAME additive_core
+%else
+%define NAME _additive_core
+%endif
 %define r(n) r%+n
 %define PSIZE 8
 %define STACK_OFFSET (4*8 + 2*16 + 8)
@@ -13,7 +17,13 @@
 
 global NAME
 
+%ifidn __OUTPUT_FORMAT__, win32
 section sec text align=1
+%elifidn __OUTPUT_FORMAT__, win64
+section sec text align=1
+%else
+section .text align=1
+%endif
 NAME:
 	; Disable denormals
 	push			r(ax)


### PR DESCRIPTION
This fixes the `cargo build --release --target=x86_64-apple-darwin` and `cargo build --release --target=i686-apple-darwin`.

Notes:
* the nasm version that comes with MacOS Sierra is a 0.98.40 and complains about the *macho64* architecture that the *nasm-rs* build-dependencie tries to target. So I used the homebrew version that is a 2.12.02 and works fine. So AFAIK `brew install nasm` is a prerequisite.
* loading the plugin in Renoise shows the controls but crashes at first note input in the process function, so it's sadly just the start of the work to have a working port!